### PR TITLE
为静态函数提供可根据环境适配的泛型约束。在其它类jvm语言中对于泛型限界有更严格的要求。比如scala。

### DIFF
--- a/cola-framework/cola-common/src/main/java/com/alibaba/cola/dto/Response.java
+++ b/cola-framework/cola-common/src/main/java/com/alibaba/cola/dto/Response.java
@@ -50,7 +50,7 @@ public class Response extends DTO{
         return "Response [isSuccess=" + isSuccess + ", errCode=" + errCode + ", errMessage=" + errMessage + "]";
     }
 
-    public static Response buildFailure(String errCode, String errMessage) {
+    public static <T> Response buildFailure(String errCode, String errMessage) {
         Response response = new Response();
         response.setSuccess(false);
         response.setErrCode(errCode);
@@ -58,7 +58,7 @@ public class Response extends DTO{
         return response;
     }
 
-    public static Response buildSuccess(){
+    public static <T> Response buildSuccess(){
         Response response = new Response();
         response.setSuccess(true);
         return response;

--- a/cola-framework/cola-common/src/main/java/com/alibaba/cola/dto/SingleResponse.java
+++ b/cola-framework/cola-common/src/main/java/com/alibaba/cola/dto/SingleResponse.java
@@ -25,16 +25,16 @@ public class SingleResponse<T> extends Response {
         this.data = data;
     }
 
-    public static SingleResponse buildFailure(String errCode, String errMessage) {
-        SingleResponse response = new SingleResponse();
+    public static <T> SingleResponse<T> buildFailure(String errCode, String errMessage) {
+        SingleResponse<T> response = new SingleResponse<T>();
         response.setSuccess(false);
         response.setErrCode(errCode);
         response.setErrMessage(errMessage);
         return response;
     }
 
-    public static SingleResponse buildSuccess(){
-        SingleResponse response = new SingleResponse();
+    public static <T> SingleResponse<T> buildSuccess(){
+        SingleResponse<T> response = new SingleResponse<T>();
         response.setSuccess(true);
         return response;
     }


### PR DESCRIPTION
为了让Response及其在scala环境中同样可以正常工作