### PR TITLE
fix: can not loop find extension

### DIFF
--- a/cola-framework/cola-common/pom.xml
+++ b/cola-framework/cola-common/pom.xml
@@ -10,6 +10,12 @@
 	<artifactId>cola-common</artifactId>
 	<version>${cola.framework.version}</version>
 	<name>cola-common</name>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+	</dependencies>
 	<build>
 		<plugins>
 			<plugin>

--- a/cola-framework/cola-common/src/main/java/com/alibaba/cola/extension/BizScenario.java
+++ b/cola-framework/cola-common/src/main/java/com/alibaba/cola/extension/BizScenario.java
@@ -1,6 +1,8 @@
 package com.alibaba.cola.extension;
 
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * BizScenario（业务场景）= bizId + useCase + scenario, which can uniquely identify a user scenario.
  *
@@ -9,8 +11,8 @@ package com.alibaba.cola.extension;
  */
 public class BizScenario {
     public final static String DEFAULT_BIZ_ID = "defaultBizId";
-    public final static String DEFAULT_USE_CASE = "defaultUseCase";
-    public final static String DEFAULT_SCENARIO = "defaultScenario";
+    public final static String DEFAULT_USE_CASE = "";
+    public final static String DEFAULT_SCENARIO = "";
     private final static String DOT_SEPARATOR = ".";
 
     /**
@@ -35,7 +37,14 @@ public class BizScenario {
      * @return
      */
     public String getUniqueIdentity(){
-        return bizId + DOT_SEPARATOR + useCase + DOT_SEPARATOR + scenario;
+        String uniqueIdentity = bizId;
+        if (StringUtils.isNotBlank(useCase)) {
+            uniqueIdentity = uniqueIdentity + DOT_SEPARATOR + useCase;
+        }
+        if (StringUtils.isNotBlank(scenario)) {
+            uniqueIdentity = uniqueIdentity + DOT_SEPARATOR + scenario;
+        }
+        return uniqueIdentity;
     }
 
     public static BizScenario valueOf(String bizId, String useCase, String scenario){


### PR DESCRIPTION
 # bug 描述
找不到扩展点。
例如扩展点为： 
```
@Extension(bizId = ali)
public class ValidateExt {
      ...
}
```
COLA框架在`extensionRepository`中注册的扩展点对应关系为:
`ali.defaultUseCase.defaultScenario`  -> `ValidateExt`
当身份为: `ali.tmall.supermarket` 的command执行的时候，找不到该扩展点。
寻找扩展点的逻辑如下:
```
    /**
     * if the bizScenarioUniqueIdentity is "ali.tmall.supermarket"
     *
     * the search path is as below:
     * 1、first try to get extension by "ali.tmall.supermarket", if get, return it.
     * 2、loop try to get extension by "ali.tmall", if get, return it.
     * 3、loop try to get extension by "ali", if get, return it.
     * 4、if not found, try the default extension
     * @param targetClz
     */
```
# bug fix
有两种办法可以解该Bug。
## 1.注册循环多条扩展点数据：
`ali.defaultUseCase.defaultScenario`  -> `ValidateExt`
`ali.defaultUseCase`  -> `ValidateExt`
`ali`  -> `ValidateExt`

## 2. 注册的时候注册
`ali`  -> `ValidateExt`
寻找扩展点逻辑不变，还是循环寻找扩展点。
最终选择第二种，不违背最开始设计思路，也节省内存中存冗余数据。
