### PR TITLE
fix(ExtensionRegister): 解决拓展点实现类被动态代理时无法正常注册的问题

### DIFF
--- a/cola-framework-core/src/main/java/com/alibaba/cola/boot/ExtensionRegister.java
+++ b/cola-framework-core/src/main/java/com/alibaba/cola/boot/ExtensionRegister.java
@@ -10,12 +10,14 @@ package com.alibaba.cola.boot;
 import com.alibaba.cola.common.ColaConstant;
 import com.alibaba.cola.exception.framework.ColaException;
 import com.alibaba.cola.extension.*;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
 
 import javax.annotation.Resource;
 
 /**
- * ExtensionRegister 
+ * ExtensionRegister
  * @author fulan.zjf 2017-11-05
  */
 @Component
@@ -27,6 +29,9 @@ public class ExtensionRegister{
 
     public void doRegistration(ExtensionPointI extensionObject){
         Class<?>  extensionClz = extensionObject.getClass();
+        if (AopUtils.isAopProxy(extensionObject)) {
+            extensionClz = ClassUtils.getUserClass(extensionObject);
+        }
         Extension extensionAnn = extensionClz.getDeclaredAnnotation(Extension.class);
         BizScenario bizScenario = BizScenario.valueOf(extensionAnn.bizId(), extensionAnn.useCase(), extensionAnn.scenario());
         ExtensionCoordinate extensionCoordinate = new ExtensionCoordinate(calculateExtensionPoint(extensionClz), bizScenario.getUniqueIdentity());


### PR DESCRIPTION
如果拓展点实现类被动态代理，原代码无法正常获取类上的@Extension注解导致NPE。

因为@Extension注解加了@Inherited，一开始的解决思路是直接用extensionClz.getAnnotation(Extension.class)替换掉getDeclaredAnnotation()，不过之后又会获取不到ExtPt接口导致注册失败，遂放弃。

现在的解决方案是，判断如果目标对象是个AOP代理对象，则直接获取其定义类，进而反射获得注解和接口定义。