### PR TITLE
框架的观察者模式部分bugfix

### DIFF
--- a/cola-framework-core/src/main/java/com/alibaba/cola/boot/EventRegister.java
+++ b/cola-framework-core/src/main/java/com/alibaba/cola/boot/EventRegister.java
@@ -9,6 +9,7 @@ package com.alibaba.cola.boot;
 
 import com.alibaba.cola.common.ApplicationContextHelper;
 import com.alibaba.cola.common.ColaConstant;
+import com.alibaba.cola.dto.Response;
 import com.alibaba.cola.event.EventI;
 import com.alibaba.cola.event.EventHandlerI;
 import com.alibaba.cola.event.EventHub;
@@ -42,16 +43,40 @@ public class EventRegister{
                                  + "() is not detected");
     }
 
+    @SuppressWarnings("unchecked")
+    private Class<? extends Response> getResponseFromExecutor(Class<?> eventExecutorClz){
+        Method[] methods = eventExecutorClz.getDeclaredMethods();
+        for (Method method : methods) {
+            if (isExecuteMethod(method)){
+                Class<?> clazz = method.getReturnType();
+                if (Response.class.isAssignableFrom(clazz)) {
+                    return (Class<? extends Response>) clazz;
+                }
+            }
+        }
+        throw new ColaException("Execute method ReturnType in " + eventExecutorClz.getSimpleName() + " should be the subClass of Response");
+    }
+
+    /**
+     * 根据事件处理器实例注册
+     * 1. 事件和事件处理器的映射关系
+     * 2. 事件处理器和返回类的映射关系 (用于异常处理)
+     *
+     * @param eventHandler 事件处理器
+     */
     public void doRegistration(EventHandlerI eventHandler){
         Class<? extends EventI> eventClz = getEventFromExecutor(eventHandler.getClass());
         eventHub.register(eventClz, eventHandler);
+        Class<? extends Response> responseClz = getResponseFromExecutor(eventHandler.getClass());
+        eventHub.register(eventHandler.getClass(), responseClz);
     }
 
     private boolean isExecuteMethod(Method method){
         return ColaConstant.EXE_METHOD.equals(method.getName()) && !method.isBridge();
     }
 
-    private Class checkAndGetEventParamType(Method method){
+    @SuppressWarnings("unchecked")
+    private Class<? extends EventI> checkAndGetEventParamType(Method method){
         Class<?>[] exeParams = method.getParameterTypes();
         if (exeParams.length == 0){
             throw new ColaException("Execute method in "+method.getDeclaringClass()+" should at least have one parameter");
@@ -59,6 +84,6 @@ public class EventRegister{
         if(!EventI.class.isAssignableFrom(exeParams[0]) ){
             throw new ColaException("Execute method in "+method.getDeclaringClass()+" should be the subClass of Event");
         }
-        return exeParams[0];
+        return (Class<? extends EventI>) exeParams[0];
     }
 }

--- a/cola-framework-core/src/main/java/com/alibaba/cola/event/EventHub.java
+++ b/cola-framework-core/src/main/java/com/alibaba/cola/event/EventHub.java
@@ -50,10 +50,9 @@ public class EventHub {
         List<EventHandlerI> eventHandlers = eventRepository.get(eventClz);
         if(eventHandlers == null){
             eventHandlers = new ArrayList<>();
-            eventRepository.put(eventClz, eventHandlers);
         }
         eventHandlers.add(executor);
-
+        eventRepository.put(eventClz, eventHandlers);
     }
 
     private List<EventHandlerI> findHandler(Class<? extends EventI> eventClass){


### PR DESCRIPTION
问题：
事件fire时，NPE；如果事件处理器抛出异常也会导致NPE

原因：
1. EventHub类的register方法注册事件和处理器无效
2. EventBus类有异常处理兜底逻辑handleException，其中会从eventHub.getResponseRepository() 获取事件处理器的Response
3. EventRegister的doRegistration 并没有注册 Executor 和 Response的关系