### PR TITLE
bizScenario被设置为初始化值的问题

### DIFF
--- a/cola-framework-common/src/main/java/com/alibaba/cola/extension/BizScenario.java
+++ b/cola-framework-common/src/main/java/com/alibaba/cola/extension/BizScenario.java
@@ -59,13 +59,10 @@ public class BizScenario {
     }
 
     public String getIdentityWithDefaultScenario(){
-        this.scenario = DEFAULT_SCENARIO;
-        return getUniqueIdentity();
+        return bizId + DOT_SEPARATOR + useCase + DOT_SEPARATOR + DEFAULT_SCENARIO;
     }
 
     public String getIdentityWithDefaultUseCase(){
-        this.scenario = DEFAULT_SCENARIO;
-        this.useCase = DEFAULT_USE_CASE;
-        return getUniqueIdentity();
+        return bizId + DOT_SEPARATOR + DEFAULT_USE_CASE + DOT_SEPARATOR + DEFAULT_SCENARIO;
     }
 }


### PR DESCRIPTION
### 在bizScenario的get方法中修改属性值容易导致使用问题

## case1
1. `bizScenario`值设置为, `BIZ1.USE_CASE1.SCENARIO1`
2. 打印日志 `log.info("[init提单cmd] placeOrderCmd={}", JSON.toJSONString(placeOrderCmd))`
由于fastjson会自动调用get方法
3. 在打印完日志之后,`bizScenario`被设置为初始化值`BIZ1.#defaultUseCase#.#defaultScenario#`

## case2
1. 存在3个`extension`顺序执行1,2,3
2. `extension1`, 存在设置为`BIZ1.USE_CASE1.#defaultScenario#`以及`BIZ1.USE_CASE1.SCENARIO1`的实现类
2. `extension2`,只存在设置为`BIZ1.USE_CASE1.#defaultScenario#`的实现类
3. `extension3`,存在设置为`BIZ1.USE_CASE1.#defaultScenario#`以及`BIZ1.USE_CASE1.SCENARIO1`的实现类
4. 当传入`bizScenario`值设置为, `BIZ1.USE_CASE1.SCENARIO1`
5. `extension1`可以正常执行,但执行`extension2`之后,`bizScenario`的值被设置为`BIZ1.USE_CASE1.#defaultScenario#`
6. `extension3`无法执行期望的`BIZ1.USE_CASE1.SCENARIO1`的实现类

总的来说比较不利于使用理解/使用/问题排查,望采纳