### PR TITLE
improve maven build stability and unify pom format

### DIFF
--- a/cola-archetypes/cola-archetype-service/pom.xml
+++ b/cola-archetypes/cola-archetype-service/pom.xml
@@ -44,6 +44,12 @@
         </developer>
     </developers>
 
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <build>
         <extensions>
             <extension>
@@ -76,13 +82,13 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
+                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/cola-archetypes/cola-archetype-service/pom.xml
+++ b/cola-archetypes/cola-archetype-service/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>com.alibaba.cola</groupId>
     <artifactId>cola-framework-archetype-service</artifactId>
     <version>4.0.0</version>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
@@ -7,9 +7,11 @@
 		<version>${version}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<name>${artifactId}</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>${groupId}</groupId>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-client/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-client/pom.xml
@@ -7,9 +7,11 @@
 		<version>${version}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<name>${parentArtifactId}-client</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.alibaba.cola</groupId>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
@@ -7,9 +7,11 @@
 		<version>${version}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<name>${artifactId}</name>
+
 	<dependencies>
 		<!-- COLA components -->
 		<dependency>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-infrastructure/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-infrastructure/pom.xml
@@ -7,9 +7,11 @@
 		<version>${version}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<name>${artifactId}</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>${groupId}</groupId>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <packaging>pom</packaging>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,6 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <mybatis-starter.version>1.3.1</mybatis-starter.version>
@@ -141,6 +140,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/start/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/start/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>${groupId}</groupId>
         <artifactId>${rootArtifactId}</artifactId>
@@ -8,7 +8,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>${artifactId}</artifactId>
     <packaging>jar</packaging>
     <name>${artifactId}</name>

--- a/cola-archetypes/cola-archetype-web/pom.xml
+++ b/cola-archetypes/cola-archetype-web/pom.xml
@@ -43,6 +43,12 @@
     </developer>
   </developers>
 
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <build>
     <extensions>
       <extension>
@@ -75,13 +81,13 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.2.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <encoding>UTF-8</encoding>
-        </configuration>
+        <version>3.8.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/cola-archetypes/cola-archetype-web/pom.xml
+++ b/cola-archetypes/cola-archetype-web/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>com.alibaba.cola</groupId>
   <artifactId>cola-framework-archetype-web</artifactId>
   <version>4.0.0</version>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-adapter/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-adapter/pom.xml
@@ -7,9 +7,11 @@
         <version>${version}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
     <name>${artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>${groupId}</groupId>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
@@ -7,9 +7,11 @@
 		<version>${version}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<name>${artifactId}</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>${groupId}</groupId>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-client/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-client/pom.xml
@@ -7,9 +7,11 @@
 		<version>${version}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<name>${parentArtifactId}-client</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.alibaba.cola</groupId>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
@@ -7,9 +7,11 @@
 		<version>${version}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<name>${artifactId}</name>
+
 	<dependencies>
 		<!-- COLA components -->
 		<dependency>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-infrastructure/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-infrastructure/pom.xml
@@ -7,9 +7,11 @@
 		<version>${version}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<name>${artifactId}</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>${groupId}</groupId>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <packaging>pom</packaging>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,6 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <mybatis-starter.version>1.3.1</mybatis-starter.version>
@@ -148,6 +147,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/start/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/start/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>${groupId}</groupId>
         <artifactId>${rootArtifactId}</artifactId>
@@ -8,7 +8,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>${artifactId}</artifactId>
     <packaging>jar</packaging>
     <name>${artifactId}</name>

--- a/cola-archetypes/pom.xml
+++ b/cola-archetypes/pom.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>com.alibaba.cola</groupId>
     <artifactId>cola-archeytpes</artifactId>
     <packaging>pom</packaging>

--- a/cola-archetypes/pom.xml
+++ b/cola-archetypes/pom.xml
@@ -10,9 +10,9 @@
     <name>cola-archeytpes</name>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/cola-components/archetypes/cola-normal-component-archetype/pom.xml
+++ b/cola-components/archetypes/cola-normal-component-archetype/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.alibaba.cola</groupId>

--- a/cola-components/archetypes/cola-normal-component-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cola-components/archetypes/cola-normal-component-archetype/src/main/resources/archetype-resources/pom.xml
@@ -9,9 +9,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -30,6 +30,5 @@
             <scope>provided</scope>
         </dependency>
 
-  
     </dependencies>
 </project>

--- a/cola-components/archetypes/cola-starter-component-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cola-components/archetypes/cola-starter-component-archetype/src/main/resources/archetype-resources/pom.xml
@@ -9,9 +9,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>2.2.6.RELEASE</spring.boot.version>
     </properties>
 

--- a/cola-components/cola-component-catchlog-starter/pom.xml
+++ b/cola-components/cola-component-catchlog-starter/pom.xml
@@ -9,9 +9,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>2.2.6.RELEASE</spring.boot.version>
         <cola.version>1.0.0</cola.version>
     </properties>
@@ -84,4 +84,18 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/cola-components/cola-component-domain-starter/pom.xml
+++ b/cola-components/cola-component-domain-starter/pom.xml
@@ -9,9 +9,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>2.2.6.RELEASE</spring.boot.version>
     </properties>
 
@@ -43,5 +43,20 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/cola-components/cola-component-dto/pom.xml
+++ b/cola-components/cola-component-dto/pom.xml
@@ -9,9 +9,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -30,6 +30,20 @@
             <scope>provided</scope>
         </dependency>
 
-  
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/cola-components/cola-component-exception/pom.xml
+++ b/cola-components/cola-component-exception/pom.xml
@@ -9,9 +9,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -30,6 +30,20 @@
             <scope>provided</scope>
         </dependency>
 
-  
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/cola-components/cola-component-extension-starter/pom.xml
+++ b/cola-components/cola-component-extension-starter/pom.xml
@@ -9,9 +9,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>2.2.6.RELEASE</spring.boot.version>
         <cola.version>1.0.0</cola.version>
     </properties>
@@ -91,5 +91,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/cola-components/cola-component-statemachine/pom.xml
+++ b/cola-components/cola-component-statemachine/pom.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>com.alibaba.cola</groupId>
     <artifactId>cola-component-statemachine</artifactId>
     <packaging>jar</packaging>

--- a/cola-components/cola-component-statemachine/pom.xml
+++ b/cola-components/cola-component-statemachine/pom.xml
@@ -45,6 +45,11 @@
         </developer>
     </developers>
 
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -74,13 +79,13 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
+                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/cola-components/cola-component-test-container/pom.xml
+++ b/cola-components/cola-component-test-container/pom.xml
@@ -9,9 +9,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -63,4 +63,19 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/cola-components/pom.xml
+++ b/cola-components/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>com.alibaba.cola</groupId>
     <artifactId>cola-components</artifactId>
     <packaging>pom</packaging>

--- a/cola-components/pom.xml
+++ b/cola-components/pom.xml
@@ -9,9 +9,9 @@
     <name>cola-components</name>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>
@@ -22,5 +22,5 @@
         <module>cola-component-extension-starter</module>
         <module>cola-component-catchlog-starter</module>
         <module>cola-component-test-container</module>
-  </modules>
+    </modules>
 </project>

--- a/sample/craftsman/craftsman-app/pom.xml
+++ b/sample/craftsman/craftsman-app/pom.xml
@@ -7,9 +7,11 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>craftsman-app</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<name>craftsman-app</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.alibaba.craftsman</groupId>

--- a/sample/craftsman/craftsman-client/pom.xml
+++ b/sample/craftsman/craftsman-client/pom.xml
@@ -7,9 +7,11 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>craftsman-client</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<name>craftsman-client</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.aliyun</groupId>

--- a/sample/craftsman/craftsman-controller/pom.xml
+++ b/sample/craftsman/craftsman-controller/pom.xml
@@ -7,9 +7,11 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>craftsman-controller</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <name>craftsman-controller</name>
+
     <dependencies>
         <dependency>
             <groupId>com.alibaba.craftsman</groupId>

--- a/sample/craftsman/craftsman-domain/pom.xml
+++ b/sample/craftsman/craftsman-domain/pom.xml
@@ -7,9 +7,11 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>craftsman-domain</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<name>craftsman-domain</name>
+
 	<dependencies>
 		<!-- COLA Framework -->
 		<dependency>

--- a/sample/craftsman/craftsman-infrastructure/pom.xml
+++ b/sample/craftsman/craftsman-infrastructure/pom.xml
@@ -7,9 +7,11 @@
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
+
 	<artifactId>craftsman-infrastructure</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<name>craftsman-infrastructure</name>
+
 	<dependencies>
 		<!--DIP here, Infrastructure depends on Domain-->
 		<dependency>

--- a/sample/craftsman/pom.xml
+++ b/sample/craftsman/pom.xml
@@ -11,7 +11,6 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <mybatis-starter.version>1.3.1</mybatis-starter.version>
@@ -150,11 +149,21 @@
                     <version>3.0.1</version>
                 </plugin>
                 <plugin>
-          				<artifactId>maven-deploy-plugin</artifactId>
-          				<configuration>
-          					<skip>true</skip>
-          				</configuration>
-          			</plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/sample/craftsman/pom.xml
+++ b/sample/craftsman/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>com.alibaba.craftsman</groupId>
     <artifactId>craftsman.all</artifactId>
     <packaging>pom</packaging>

--- a/sample/craftsman/start/pom.xml
+++ b/sample/craftsman/start/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.alibaba.craftsman</groupId>
         <artifactId>craftsman.all</artifactId>
@@ -8,7 +8,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>start</artifactId>
     <packaging>jar</packaging>
     <name>start</name>


### PR DESCRIPTION
- improve maven build stability
    - fix maven-resources-plugin encoding warning
      [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
    - unify maven-compiler-plugin config: via properties(project.build.sourceEncoding/maven.compiler.source)
    - upgrade/unify maven-resources-plugin/maven-compiler-plugin version
- unify pom format
    - unify modelVersion element to order first
    - add a blank line between artifactId element and parent/modelVersion
    - add a blank line before dependencies element
