### PR TITLE
 解决现有骨架工程里的模块依赖关系不符合COLA架构范式的问题

### DIFF
--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
@@ -18,10 +18,6 @@
             <artifactId>${rootArtifactId}-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>${groupId}</groupId>
-            <artifactId>${rootArtifactId}-infrastructure</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.alibaba.cola</groupId>
             <artifactId>cola-component-catchlog-starter</artifactId>
         </dependency>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>${rootArtifactId}-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>${groupId}</groupId>
+            <artifactId>${rootArtifactId}-domain</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba.cola</groupId>
             <artifactId>cola-component-catchlog-starter</artifactId>
         </dependency>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
@@ -24,8 +24,8 @@
         </dependency>
         <!-- COLA components End-->
         <dependency>
-            <groupId>${groupId}</groupId>
-            <artifactId>${rootArtifactId}-client</artifactId>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
         </dependency>
     </dependencies>
 

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
@@ -27,6 +27,10 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-infrastructure/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/__rootArtifactId__-infrastructure/pom.xml
@@ -29,9 +29,5 @@
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/start/pom.xml
+++ b/cola-archetypes/cola-archetype-service/src/main/resources/archetype-resources/start/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>${rootArtifactId}-app</artifactId>
         </dependency>
         <dependency>
+            <groupId>${groupId}</groupId>
+            <artifactId>${rootArtifactId}-infrastructure</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
             <scope>test</scope>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
@@ -18,10 +18,6 @@
             <artifactId>${rootArtifactId}-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>${groupId}</groupId>
-            <artifactId>${rootArtifactId}-infrastructure</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.alibaba.cola</groupId>
             <artifactId>cola-component-catchlog-starter</artifactId>
         </dependency>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-app/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>${rootArtifactId}-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>${groupId}</groupId>
+            <artifactId>${rootArtifactId}-domain</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba.cola</groupId>
             <artifactId>cola-component-catchlog-starter</artifactId>
         </dependency>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
@@ -23,6 +23,14 @@
             <artifactId>cola-component-exception</artifactId>
         </dependency>
         <!-- COLA components End-->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
@@ -23,10 +23,6 @@
             <artifactId>cola-component-exception</artifactId>
         </dependency>
         <!-- COLA components End-->
-        <dependency>
-            <groupId>${groupId}</groupId>
-            <artifactId>${rootArtifactId}-client</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/start/pom.xml
+++ b/cola-archetypes/cola-archetype-web/src/main/resources/archetype-resources/start/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>${rootArtifactId}-adapter</artifactId>
         </dependency>
         <dependency>
+            <groupId>${groupId}</groupId>
+            <artifactId>${rootArtifactId}-infrastructure</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Fixes #159
1、去除app对infrastructure的依赖,增加对domain的依赖
2、去除domain对client的依赖
3、增加start对infrastructure