### PR TITLE
MultiResponse和PageResponse的getData方法性能优化

### DIFF
--- a/cola-components/cola-component-dto/src/main/java/com/alibaba/cola/dto/MultiResponse.java
+++ b/cola-components/cola-component-dto/src/main/java/com/alibaba/cola/dto/MultiResponse.java
@@ -18,7 +18,13 @@ public class MultiResponse<T> extends Response {
     private Collection<T> data;
 
     public List<T> getData() {
-        return null == data ? Collections.emptyList() : new ArrayList<>(data);
+        if (null == data) {
+            return Collections.emptyList();
+        }
+        if (data instanceof List) {
+            return (List<T>) data;
+        }
+        return new ArrayList<>(data);
     }
 
     public void setData(Collection<T> data) {

--- a/cola-components/cola-component-dto/src/main/java/com/alibaba/cola/dto/PageResponse.java
+++ b/cola-components/cola-component-dto/src/main/java/com/alibaba/cola/dto/PageResponse.java
@@ -62,7 +62,13 @@ public class PageResponse<T> extends Response {
     }
 
     public List<T> getData() {
-        return null == data ? Collections.emptyList() : new ArrayList<>(data);
+        if (null == data) {
+            return Collections.emptyList();
+        }
+        if (data instanceof List) {
+            return (List<T>) data;
+        }
+        return new ArrayList<>(data);
     }
 
     public void setData(Collection<T> data) {


### PR DESCRIPTION
multiResponse和pageResponse的getData方法， spring在每次序列化时都会调用（jackson）。
当前的方法是每一次调用都会new一个ArrayList， 可以先判断一下， 尽量提升下性能。