### PR TITLE
fix: add order for CatchLogAspect

### DIFF
--- a/cola-components/cola-component-catchlog-starter/src/main/java/com/alibaba/cola/catchlog/CatchLogAspect.java
+++ b/cola-components/cola-component-catchlog-starter/src/main/java/com/alibaba/cola/catchlog/CatchLogAspect.java
@@ -11,6 +11,7 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.Order;
 
 /**
  * @ Description   :  Catching and Logging
@@ -20,6 +21,7 @@ import org.aspectj.lang.reflect.MethodSignature;
  */
 @Aspect
 @Slf4j
+@Order(1)
 public class CatchLogAspect {
 
     /**


### PR DESCRIPTION
Solve the problem that the transaction does not take effect due to the exception swallowed by the log interceptor