### PR TITLE
Remove the domain's dependency on the client

### DIFF
--- a/samples/craftsman/craftsman-domain/pom.xml
+++ b/samples/craftsman/craftsman-domain/pom.xml
@@ -26,10 +26,6 @@
             <groupId>com.alibaba.cola</groupId>
             <artifactId>cola-component-exception</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.alibaba.craftsman</groupId>
-            <artifactId>craftsman-client</artifactId>
-        </dependency>
         <!-- COLA Framework End-->
         <dependency>
             <groupId>junit</groupId>
@@ -42,6 +38,10 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
         </dependency>
     </dependencies>
 

--- a/samples/craftsman/craftsman-infrastructure/pom.xml
+++ b/samples/craftsman/craftsman-infrastructure/pom.xml
@@ -18,6 +18,10 @@
             <groupId>com.alibaba.craftsman</groupId>
             <artifactId>craftsman-domain</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba.craftsman</groupId>
+            <artifactId>craftsman-client</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.mybatis.spring.boot</groupId>


### PR DESCRIPTION
Domain 层通过 geteway 接口完成对 Infrastructure 层的依赖倒置，使得 Domain 层作为业务核心，可以做到不依赖于任何的外部模块，也贴近于“六边形”和“洋葱”等架构的核心理念。

依赖问题的核心其实是 Infrastructure 层作为 Application 层的依赖，要为其提供将用户请求的 clientobject 转换为 entity 的功能（设计），导致 Infrastructure 层必须要依赖于 Client 模块，个人认为这层依赖关系不应该通过依赖于 Domain 层来隐藏，暴露出这层依赖可能会更有利于以后架构上的调整。