### PR TITLE
fix aop use jdk dynamic proxy NPE issue

### DIFF
--- a/cola-components/cola-component-extension-starter/src/main/java/com/alibaba/cola/extension/register/ExtensionRegister.java
+++ b/cola-components/cola-component-extension-starter/src/main/java/com/alibaba/cola/extension/register/ExtensionRegister.java
@@ -10,6 +10,7 @@ package com.alibaba.cola.extension.register;
 import com.alibaba.cola.extension.*;
 
 import org.springframework.aop.support.AopUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ClassUtils;
@@ -17,7 +18,7 @@ import org.springframework.util.ClassUtils;
 import javax.annotation.Resource;
 
 /**
- * ExtensionRegister 
+ * ExtensionRegister
  * @author fulan.zjf 2017-11-05
  */
 @Component
@@ -32,9 +33,9 @@ public class ExtensionRegister{
     public void doRegistration(ExtensionPointI extensionObject){
         Class<?>  extensionClz = extensionObject.getClass();
         if (AopUtils.isAopProxy(extensionObject)) {
-            extensionClz = ClassUtils.getUserClass(extensionObject);
+            extensionClz = AopUtils.getTargetClass(extensionObject);
         }
-        Extension extensionAnn = AnnotationUtils.findAnnotation(extensionClz, Extension.class);
+        Extension extensionAnn = AnnotatedElementUtils.findMergedAnnotation(extensionClz, Extension.class);
         BizScenario bizScenario = BizScenario.valueOf(extensionAnn.bizId(), extensionAnn.useCase(), extensionAnn.scenario());
         ExtensionCoordinate extensionCoordinate = new ExtensionCoordinate(calculateExtensionPoint(extensionClz), bizScenario.getUniqueIdentity());
         ExtensionPointI preVal = extensionRepository.getExtensionRepo().put(extensionCoordinate, extensionObject);


### PR DESCRIPTION
AOP使用jdk代理时，会获取不到注解@Extension的值，导致启动时出错.
建议后续获取注解逻辑与ExtensionBootstrap中ApplicationContext.getBeansWithAnnotation中保持一致；