### PR TITLE
442: TransitionsBuilderImpl cannot be inherited from TransitionBuilderImpl…

### DIFF
--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/builder/AbstractTransitionBuilder.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/builder/AbstractTransitionBuilder.java
@@ -1,0 +1,43 @@
+package com.alibaba.cola.statemachine.builder;
+
+import com.alibaba.cola.statemachine.State;
+import com.alibaba.cola.statemachine.impl.StateHelper;
+import com.alibaba.cola.statemachine.impl.TransitionType;
+
+import java.util.Map;
+
+/**
+ * Take TransitionBuilderImpl and TransitionsBuilderImpl sharing variables
+ * and methods to that abstract class, which acts as their parent,
+ * instead of having TransitionsBuilderImpl inherit from
+ * TransitionsBuilderImpl. I think that the multi-flow
+ * builder(TransitionsBuilderImpl) and single-flow
+ * builder(TransitionBuilderImpl) are equal and not supposed to be
+ * parent-child relationship, they from, when, and perform methods
+ * are not the same, and although it looks like just a set of loops
+ * but logically should not be inherited over Override.
+ * ( Just as there was no relationship, why should we talk to each other,
+ * say a we are not suitable). With the abstract class, multi-flow and single-flow
+ * only use to focus on their respective functions are single-flow,
+ * or multi-flow. Conform to a single duty.
+ * @author welliem
+ * @date 2023-07-14 12:13
+ */
+ abstract class AbstractTransitionBuilder<S,E,C> implements  From<S,E,C>,On<S,E,C>,To<S,E,C>{
+
+    final Map<S, State<S, E, C>> stateMap;
+
+    protected State<S, E, C> target;
+
+    final TransitionType transitionType;
+
+    public AbstractTransitionBuilder(Map<S, State<S, E, C>> stateMap, TransitionType transitionType) {
+        this.stateMap = stateMap;
+        this.transitionType = transitionType;
+    }
+    @Override
+    public To<S, E, C> to(S stateId) {
+        target = StateHelper.getState(stateMap, stateId);
+        return this;
+    }
+}

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/builder/TransitionBuilderImpl.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/builder/TransitionBuilderImpl.java
@@ -15,32 +15,19 @@ import java.util.Map;
  * @author Frank Zhang
  * @date 2020-02-07 10:20 PM
  */
-class TransitionBuilderImpl<S,E,C> implements ExternalTransitionBuilder<S,E,C>, InternalTransitionBuilder<S,E,C>, From<S,E,C>, On<S,E,C>, To<S,E,C> {
+class TransitionBuilderImpl<S,E,C> extends AbstractTransitionBuilder<S,E,C> implements ExternalTransitionBuilder<S,E,C>, InternalTransitionBuilder<S,E,C> {
 
-    final Map<S, State<S, E, C>> stateMap;
 
     private State<S, E, C> source;
-
-    protected State<S, E, C> target;
-
     private Transition<S, E, C> transition;
 
-    final TransitionType transitionType;
-
     public TransitionBuilderImpl(Map<S, State<S, E, C>> stateMap, TransitionType transitionType) {
-        this.stateMap = stateMap;
-        this.transitionType = transitionType;
+        super(stateMap, transitionType);
     }
 
     @Override
     public From<S, E, C> from(S stateId) {
         source = StateHelper.getState(stateMap, stateId);
-        return this;
-    }
-
-    @Override
-    public To<S, E, C> to(S stateId) {
-        target = StateHelper.getState(stateMap, stateId);
         return this;
     }
 

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/builder/TransitionsBuilderImpl.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/builder/TransitionsBuilderImpl.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * @author Frank Zhang
  * @date 2020-02-08 7:43 PM
  */
-public class TransitionsBuilderImpl<S,E,C> extends TransitionBuilderImpl<S,E,C> implements ExternalTransitionsBuilder<S,E,C> {
+public class TransitionsBuilderImpl<S,E,C> extends AbstractTransitionBuilder<S,E,C> implements ExternalTransitionsBuilder<S,E,C> {
     /**
      * This is for fromAmong where multiple sources can be configured to point to one target
      */


### PR DESCRIPTION
`TransitionsBuilderImpl`和`TransitionBuilderImpl`应该是平级关系，而不应该是继承关系。

因为多流转和单流转本来就是平级的类间关系，如果用继承，多流转`transitions`重写了单流转`transition`的多个连贯接口方法。不合理的。

是否可以让他们继承同一个抽象类：

```java
abstract class AbstractTransitionBuilder<S,E,C> implements From<S,E,C>, On<S,E,C>, To<S,E,C>
```

然后他们分别实现连贯接口中的方法。

这样也清晰了，同时符合单一职责原则；
否则继承的话，`TransitionBuilderImpl`被动的承担了多流转的责任，只是我们用`Override`掩盖了这一事实。