### PR TITLE
feat: 为状态机增加获取targetState、targetStateChain功能

### DIFF
--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/State.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/State.java
@@ -36,6 +36,8 @@ public interface State<S,E,C> extends Visitable{
 
     List<Transition<S,E,C>> getEventTransitions(E event);
 
+    List<Transition<S,E,C>> getEventTransitions(E event, TransitionType transitionType);
+
     Collection<Transition<S,E,C>> getAllTransitions();
 
 }

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChain.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChain.java
@@ -1,0 +1,45 @@
+package com.alibaba.cola.statemachine;
+
+import java.util.List;
+
+/**
+ * StateChain
+ *
+ * @author benym
+ * @date 2024/6/11 23:15
+ */
+public interface StateChain<S, E> extends StateChainVisitable {
+
+    /**
+     * Gets the source state of stateChain
+     *
+     * @return the source state
+     */
+    S getSource();
+
+    /**
+     * Gets the list of target states for stateChain
+     *
+     * @return the list of target states
+     */
+    List<S> getTargets();
+
+    /**
+     * Gets the event of stateChain
+     *
+     * @return event
+     */
+    E getEvent();
+
+    /**
+     * Print stateChain from the console
+     */
+    void showStateChain();
+
+    /**
+     * Generate the plantUml diagram of stateChain
+     *
+     * @return String
+     */
+    String generatePlantUml();
+}

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChain.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChain.java
@@ -22,7 +22,7 @@ public interface StateChain<S, E> extends StateChainVisitable {
      *
      * @return the list of target states
      */
-    List<S> getTargets();
+    List<S> getChainStates();
 
     /**
      * Gets the event of stateChain

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChainVisitable.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChainVisitable.java
@@ -1,0 +1,18 @@
+package com.alibaba.cola.statemachine;
+
+/**
+ * StateChainVisitable
+ *
+ * @author benym
+ * @date 2024/6/12 18:07
+ */
+public interface StateChainVisitable {
+
+    /**
+     * accept StateChainVisitor and return visitor result
+     *
+     * @param visitor StateChainVisitor
+     * @return String
+     */
+    String accept(final StateChainVisitor visitor);
+}

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChainVisitor.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChainVisitor.java
@@ -1,0 +1,31 @@
+package com.alibaba.cola.statemachine;
+
+import java.util.List;
+
+/**
+ * StateChainVisitor
+ *
+ * @author benym
+ * @date 2024/6/12 18:06
+ */
+public interface StateChainVisitor {
+
+    /**
+     * @param visitable the element to be visited.
+     * @return String
+     */
+    String visitOnEntry(StateChain<?, ?> visitable);
+
+    /**
+     * @param visitable the element to be visited.
+     * @return String
+     */
+    String visitOnExit(StateChain<?, ?> visitable);
+
+    /**
+     * @param chainStateList the element to be visited.
+     * @param event event
+     * @return String
+     */
+    <S, C, E> String visitOnStateChain(List<State<S,E,C>> chainStateList, E event);
+}

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChainVisitor.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateChainVisitor.java
@@ -24,8 +24,8 @@ public interface StateChainVisitor {
 
     /**
      * @param chainStateList the element to be visited.
-     * @param event event
+     * @param event          event
      * @return String
      */
-    <S, C, E> String visitOnStateChain(List<State<S,E,C>> chainStateList, E event);
+    <S, E, C> String visitOnStateChain(List<State<S, E, C>> chainStateList, E event);
 }

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateMachine.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateMachine.java
@@ -23,6 +23,38 @@ public interface StateMachine<S, E, C> extends Visitable{
     boolean verify(S sourceStateId,E event);
 
     /**
+     * Sending an event {@code E} to the state machine
+     * Calculate the subsequent states of the current sourceState in advance
+     * This method does not actually perform state transitions
+     * Such as a given state machine
+     * STATE1 --> STATE1 : EVENT1
+     * STATE1 --> STATE2 : EVENT1
+     * When the method's sourceState is STATE1 and event is EVENT1
+     * Will return Source: STATE1, Targets: [STATE1, STATE2], Event: EVENT1
+     *
+     * @param sourceState the source state
+     * @param event the event to send
+     * @return the target state list
+     */
+    List<S> getTargetStates(S sourceState, E event);
+
+    /**
+     * Sending an event {@code E} to the state machine
+     * Calculate the subsequent state chain of the current sourceState in advance
+     * This method does not actually perform state transitions
+     * Such as a given state machine
+     * STATE1 --> STATE2 : EVENT1
+     * STATE2 --> STATE3 : EVENT1
+     * When the method's sourceState is STATE1 and event is EVENT1
+     * Will return Source: STATE1, Targets: [STATE2, STATE3], Event: EVENT1
+     *
+     * @param sourceState   the source state
+     * @param event         the event to send
+     * @return the target state chain list
+     */
+    List<StateChain<S, E>> getTargetStateChain(S sourceState, E event);
+
+    /**
      * Send an event {@code E} to the state machine.
      *
      * @param sourceState the source state

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/Transition.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/Transition.java
@@ -29,6 +29,8 @@ public interface Transition<S, E, C>{
     void setEvent(E event);
 
     void setType(TransitionType type);
+
+    TransitionType getType();
     /**
      * Gets the target state of this transition.
      *

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/Transition.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/Transition.java
@@ -31,6 +31,7 @@ public interface Transition<S, E, C>{
     void setType(TransitionType type);
 
     TransitionType getType();
+
     /**
      * Gets the target state of this transition.
      *

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/PlantUMLVisitor.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/PlantUMLVisitor.java
@@ -1,9 +1,8 @@
 package com.alibaba.cola.statemachine.impl;
 
-import com.alibaba.cola.statemachine.State;
-import com.alibaba.cola.statemachine.StateMachine;
-import com.alibaba.cola.statemachine.Transition;
-import com.alibaba.cola.statemachine.Visitor;
+import com.alibaba.cola.statemachine.*;
+
+import java.util.List;
 
 /**
  * PlantUMLVisitor
@@ -11,7 +10,7 @@ import com.alibaba.cola.statemachine.Visitor;
  * @author Frank Zhang
  * @date 2020-02-09 7:47 PM
  */
-public class PlantUMLVisitor implements Visitor {
+public class PlantUMLVisitor implements Visitor, StateChainVisitor {
 
     /**
      * Since the state machine is stateless, there is no initial state.
@@ -30,6 +29,30 @@ public class PlantUMLVisitor implements Visitor {
     @Override
     public String visitOnExit(StateMachine<?, ?, ?> visitable) {
         return "@enduml";
+    }
+
+    @Override
+    public String visitOnEntry(StateChain<?, ?> visitable) {
+        return "@startuml" + LF;
+    }
+
+    @Override
+    public String visitOnExit(StateChain<?, ?> visitable) {
+        return "@enduml";
+    }
+
+    @Override
+    public <S, C, E> String visitOnStateChain(List<State<S, E, C>> chainStateList, E event) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < chainStateList.size() - 1; i++) {
+            sb.append(chainStateList.get(i).getId())
+                    .append("->")
+                    .append(chainStateList.get(i + 1).getId())
+                    .append(": ")
+                    .append(event)
+                    .append(LF);
+        }
+        return sb.toString();
     }
 
     @Override

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/PlantUMLVisitor.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/PlantUMLVisitor.java
@@ -42,7 +42,7 @@ public class PlantUMLVisitor implements Visitor, StateChainVisitor {
     }
 
     @Override
-    public <S, C, E> String visitOnStateChain(List<State<S, E, C>> chainStateList, E event) {
+    public <S, E, C> String visitOnStateChain(List<State<S, E, C>> chainStateList, E event) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < chainStateList.size() - 1; i++) {
             sb.append(chainStateList.get(i).getId())

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateChainImpl.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateChainImpl.java
@@ -1,0 +1,71 @@
+package com.alibaba.cola.statemachine.impl;
+
+import com.alibaba.cola.statemachine.State;
+import com.alibaba.cola.statemachine.StateChain;
+import com.alibaba.cola.statemachine.StateChainVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * StateChainImpl
+ *
+ * @author benym
+ * @date 2024/6/12 0:04
+ */
+public class StateChainImpl<S, E, C> implements StateChain<S, E> {
+
+    private final State<S, E, C> sourceState;
+
+    private final E event;
+
+    private final List<State<S, E, C>> targetStates;
+
+    public StateChainImpl(State<S, E, C> sourceState, E event, List<State<S, E, C>> targetStates) {
+        this.sourceState = sourceState;
+        this.event = event;
+        this.targetStates = targetStates;
+    }
+
+    @Override
+    public S getSource() {
+        return this.sourceState.getId();
+    }
+
+    @Override
+    public List<S> getTargets() {
+        return this.targetStates.stream().map(State::getId)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public E getEvent() {
+        return this.event;
+    }
+
+    @Override
+    public void showStateChain() {
+        SysOutVisitor sysOutVisitor = new SysOutVisitor();
+        accept(sysOutVisitor);
+    }
+
+    @Override
+    public String generatePlantUml() {
+        PlantUMLVisitor plantUmlVisitor = new PlantUMLVisitor();
+        return accept(plantUmlVisitor);
+    }
+
+    @Override
+    public String accept(StateChainVisitor visitor) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(visitor.visitOnEntry(this));
+        List<State<S, E, C>> chainStateList = new ArrayList<>();
+        chainStateList.add(this.sourceState);
+        chainStateList.addAll(this.targetStates);
+        String row = visitor.visitOnStateChain(chainStateList, event);
+        sb.append(row);
+        sb.append(visitor.visitOnExit(this));
+        return sb.toString();
+    }
+}

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateChainImpl.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateChainImpl.java
@@ -34,7 +34,7 @@ public class StateChainImpl<S, E, C> implements StateChain<S, E> {
     }
 
     @Override
-    public List<S> getTargets() {
+    public List<S> getChainStates() {
         return this.targetStates.stream().map(State::getId)
                 .collect(Collectors.toList());
     }

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateImpl.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateImpl.java
@@ -7,6 +7,7 @@ import com.alibaba.cola.statemachine.Visitor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * StateImpl
@@ -50,6 +51,18 @@ public class StateImpl<S,E,C> implements State<S,E,C> {
     @Override
     public List<Transition<S, E, C>> getEventTransitions(E event) {
         return eventTransitions.get(event);
+    }
+
+    @Override
+    public List<Transition<S, E, C>> getEventTransitions(E event, TransitionType transitionType) {
+        List<Transition<S, E, C>> transitionList = this.getEventTransitions(event);
+        if (transitionList == null || transitionList.isEmpty()) {
+            Debugger.debug("There is no Transition for " + event);
+            return new ArrayList<>();
+        }
+        return transitionList.stream()
+                .filter(transition-> transition.getType().equals(transitionType))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateMachineImpl.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateMachineImpl.java
@@ -1,6 +1,7 @@
 package com.alibaba.cola.statemachine.impl;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.alibaba.cola.statemachine.*;
 import com.alibaba.cola.statemachine.builder.FailCallback;
@@ -29,7 +30,7 @@ public class StateMachineImpl<S, E, C> implements StateMachine<S, E, C> {
 
     public StateMachineImpl(Map<S, State<S, E, C>> stateMap) {
         this.stateMap = stateMap;
-        this.stateChainMap = new HashMap<>(32);
+        this.stateChainMap = new ConcurrentHashMap<>(32);
     }
 
     @Override

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateMachineImpl.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/StateMachineImpl.java
@@ -1,9 +1,19 @@
 package com.alibaba.cola.statemachine.impl;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.alibaba.cola.statemachine.*;
+import com.alibaba.cola.statemachine.State;
+import com.alibaba.cola.statemachine.StateChain;
+import com.alibaba.cola.statemachine.StateMachine;
+import com.alibaba.cola.statemachine.Transition;
+import com.alibaba.cola.statemachine.Visitor;
 import com.alibaba.cola.statemachine.builder.FailCallback;
 
 /**
@@ -47,43 +57,61 @@ public class StateMachineImpl<S, E, C> implements StateMachine<S, E, C> {
     @Override
     public List<S> getTargetStates(S sourceStateId, E event) {
         isReady();
-        State sourceState = getState(sourceStateId);
+        State<S, E, C> sourceState = getState(sourceStateId);
         List<Transition<S, E, C>> transitions = sourceState.getEventTransitions(event);
         if (transitions == null || transitions.isEmpty()) {
             Debugger.debug("There is no Transition for " + event);
             return new ArrayList<>();
         }
-        List<S> targetStates = new ArrayList<>();
+        Set<S> targetStateSet = new LinkedHashSet<>();
         for (Transition<S, E, C> transition : transitions) {
             State<S, E, C> targetState = transition.getTarget();
             S targetStateId = targetState.getId();
-            targetStates.add(targetStateId);
+            targetStateSet.add(targetStateId);
         }
-        return targetStates;
+        return new ArrayList<>(targetStateSet);
     }
 
     @Override
     public List<StateChain<S, E>> getTargetStateChain(S sourceStateId, E event) {
         isReady();
-        String key = sourceStateId.toString() + event.toString();
-        List<StateChain<S, E>> stateChains = stateChainMap.get(key);
-        if (stateChains != null && !stateChains.isEmpty()) {
-            return stateChains;
-        }
-        State sourceState = getState(sourceStateId);
-        List<Transition<S, E, C>> internalTransitions = sourceState.getEventTransitions(event, TransitionType.INTERNAL);
-        List<Transition<S, E, C>> externalTransitions = sourceState.getEventTransitions(event, TransitionType.EXTERNAL);
-        List<StateChain<S, E>> internalStateChains = buildInternalStateChains(sourceState, event, internalTransitions);
-        List<StateChain<S, E>> externalStateChains = buildExternalStateChains(sourceState, event, externalTransitions);
-        List<StateChain<S, E>> result = new ArrayList<>(internalStateChains);
-        result.addAll(externalStateChains);
-        stateChainMap.put(key, result);
-        return result;
+        String key = sourceStateId.toString() + ":" + event.toString();
+        return stateChainMap.computeIfAbsent(key, k -> {
+            State sourceState = getState(sourceStateId);
+            List<Transition<S, E, C>> internalTransitions = sourceState.getEventTransitions(event,
+                    TransitionType.INTERNAL);
+            List<Transition<S, E, C>> externalTransitions = sourceState.getEventTransitions(event,
+                    TransitionType.EXTERNAL);
+            List<StateChain<S, E>> internalStateChains = buildInternalStateChains(sourceState, event,
+                    internalTransitions);
+            List<StateChain<S, E>> externalStateChains = buildExternalStateChains(sourceState, event,
+                    externalTransitions);
+            List<StateChain<S, E>> result = new ArrayList<>(internalStateChains);
+            result.addAll(externalStateChains);
+            return result;
+        });
     }
 
-    private List<StateChain<S, E>> buildInternalStateChains(State<S, E, C> sourceState, E event, List<Transition<S, E, C>> internalTransitions) {
+    /**
+     * Build state chains for internal transitions.
+     * <p>
+     * Internal transition means the source state and target state are the same.
+     * Since all internal transitions on the same event have the same source state,
+     * we only need to take the first one to get the target state.
+     *
+     * @param sourceState         the source state
+     * @param event               the event that triggers the transition
+     * @param internalTransitions list of internal transitions
+     * @return list of state chains for internal transitions
+     */
+    private List<StateChain<S, E>> buildInternalStateChains(State<S, E, C> sourceState, E event,
+            List<Transition<S, E, C>> internalTransitions) {
         List<StateChain<S, E>> internalStateChains = new ArrayList<>();
         if (!internalTransitions.isEmpty()) {
+            // For internal transitions, source == target (same state), so we only need the
+            // first one.
+            // All internal transitions on the same event from the same source state have
+            // identical result.
             State<S, E, C> targetState = internalTransitions.get(0).getSource();
             List<State<S, E, C>> targetStateIds = new ArrayList<>();
             targetStateIds.add(targetState);
@@ -92,41 +120,55 @@ public class StateMachineImpl<S, E, C> implements StateMachine<S, E, C> {
         return internalStateChains;
     }
 
-    private List<StateChain<S, E>> buildExternalStateChains(State<S, E, C> sourceState, E event, List<Transition<S, E, C>> externalTransitions) {
+    /**
+     * Build state chains for external transitions using BFS algorithm.
+     * <p>
+     * This method finds all possible state chains from the source state through
+     * external transitions triggered by the given event. It handles:
+     * <ul>
+     * <li>Linear paths: chains that end at a state with no further transitions</li>
+     * <li>Cyclic paths: chains that loop back to a previously visited state</li>
+     * </ul>
+     * <p>
+     * The algorithm uses a queue to explore all paths in breadth-first order,
+     * storing complete paths to track visited states and detect cycles.
+     *
+     * @param sourceState         the source state
+     * @param event               the event that triggers the transitions
+     * @param externalTransitions list of external transitions from the source state
+     * @return list of all possible state chains
+     */
+    private List<StateChain<S, E>> buildExternalStateChains(State<S, E, C> sourceState, E event,
+            List<Transition<S, E, C>> externalTransitions) {
         List<StateChain<S, E>> externalStateChains = new ArrayList<>();
-        Queue<State<S, E, C>> stateQueue = new ArrayDeque<>();
-        // A precursor path to record status
-        Map<State<S, E, C>, List<State<S, E, C>>> pathMap = new HashMap<>();
-        // Initialize the queue and path mapping
+        Queue<List<State<S, E, C>>> pathQueue = new ArrayDeque<>();
         for (Transition<S, E, C> transition : externalTransitions) {
             State<S, E, C> targetState = transition.getTarget();
             List<State<S, E, C>> initialPath = new ArrayList<>();
             initialPath.add(sourceState);
             initialPath.add(targetState);
-            stateQueue.add(targetState);
-            pathMap.put(targetState, initialPath);
+            pathQueue.add(initialPath);
         }
-        while (!stateQueue.isEmpty()) {
-            State<S, E, C> currentState = stateQueue.poll();
-            List<State<S, E, C>> currentPath = pathMap.get(currentState);
-            State state = getState(currentState.getId());
+        while (!pathQueue.isEmpty()) {
+            List<State<S, E, C>> currentPath = pathQueue.poll();
+            State<S, E, C> lastState = currentPath.get(currentPath.size() - 1);
+            State<S, E, C> state = getState(lastState.getId());
             List<Transition<S, E, C>> transitions = state.getEventTransitions(event, TransitionType.EXTERNAL);
             if (transitions.isEmpty()) {
-                externalStateChains.add(new StateChainImpl<>(sourceState, event, currentPath.subList(1, currentPath.size())));
+                externalStateChains
+                        .add(new StateChainImpl<>(sourceState, event, currentPath.subList(1, currentPath.size())));
             }
             for (Transition<S, E, C> transition : transitions) {
                 State<S, E, C> targetState = transition.getTarget();
-                // Avoid loop back paths
-                if (!currentPath.contains(targetState) && !stateQueue.contains(targetState)) {
-                    List<State<S, E, C>> newPath = new ArrayList<>(currentPath);
-                    newPath.add(targetState);
-                    stateQueue.add(targetState);
-                    pathMap.put(targetState, newPath);
-                } else {
-                    // Add the path containing the loop to the result
+                if (currentPath.contains(targetState)) {
                     List<State<S, E, C>> cyclePath = new ArrayList<>(currentPath);
                     cyclePath.add(targetState);
-                    externalStateChains.add(new StateChainImpl<>(sourceState, event, cyclePath.subList(1, cyclePath.size())));
+                    externalStateChains
+                            .add(new StateChainImpl<>(sourceState, event, cyclePath.subList(1, cyclePath.size())));
+                } else {
+                    List<State<S, E, C>> newPath = new ArrayList<>(currentPath);
+                    newPath.add(targetState);
+                    pathQueue.add(newPath);
                 }
             }
         }
@@ -146,12 +188,13 @@ public class StateMachineImpl<S, E, C> implements StateMachine<S, E, C> {
 
         return transition.transit(ctx, false).getId();
     }
+
     @Override
     public List<S> fireParallelEvent(S sourceState, E event, C context) {
         isReady();
         List<Transition<S, E, C>> transitions = routeTransitions(sourceState, event, context);
         List<S> result = new ArrayList<>();
-        if (transitions == null||transitions.isEmpty()) {
+        if (transitions == null || transitions.isEmpty()) {
             Debugger.debug("There is no Transition for " + event);
             failCallback.onFail(sourceState, event, context);
             result.add(sourceState);
@@ -185,7 +228,8 @@ public class StateMachineImpl<S, E, C> implements StateMachine<S, E, C> {
 
         return transit;
     }
-    private List<Transition<S,E,C>> routeTransitions(S sourceStateId, E event, C context) {
+
+    private List<Transition<S, E, C>> routeTransitions(S sourceStateId, E event, C context) {
         State sourceState = getState(sourceStateId);
         List<Transition<S, E, C>> result = new ArrayList<>();
         List<Transition<S, E, C>> transitions = sourceState.getEventTransitions(event);

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/SysOutVisitor.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/SysOutVisitor.java
@@ -1,9 +1,8 @@
 package com.alibaba.cola.statemachine.impl;
 
-import com.alibaba.cola.statemachine.State;
-import com.alibaba.cola.statemachine.StateMachine;
-import com.alibaba.cola.statemachine.Transition;
-import com.alibaba.cola.statemachine.Visitor;
+import com.alibaba.cola.statemachine.*;
+
+import java.util.List;
 
 /**
  * SysOutVisitor
@@ -11,7 +10,7 @@ import com.alibaba.cola.statemachine.Visitor;
  * @author Frank Zhang
  * @date 2020-02-08 8:48 PM
  */
-public class SysOutVisitor implements Visitor {
+public class SysOutVisitor implements Visitor, StateChainVisitor {
 
     @Override
     public String visitOnEntry(StateMachine<?, ?, ?> stateMachine) {
@@ -25,6 +24,36 @@ public class SysOutVisitor implements Visitor {
         String exit = "------------------------";
         System.out.println(exit);
         return exit;
+    }
+
+    @Override
+    public String visitOnEntry(StateChain<?, ?> stateChain) {
+        StringBuilder sb = new StringBuilder();
+        String entry = "-----StateChain-Event:+" + stateChain.getEvent() + "------";
+        sb.append(entry).append(LF);
+        System.out.println(entry);
+        return sb.toString();
+    }
+
+    @Override
+    public String visitOnExit(StateChain<?, ?> stateChain) {
+        String exit = "-----------------------------------";
+        System.out.println(exit);
+        return exit;
+    }
+
+    @Override
+    public <S, C, E> String visitOnStateChain(List<State<S, E, C>> chainStateList, E event) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < chainStateList.size() - 1; i++) {
+            State<S, E, C> sourceState = chainStateList.get(i);
+            sb.append(sourceState.getId()).append("->");
+        }
+        if (!chainStateList.isEmpty()) {
+            sb.append(chainStateList.get(chainStateList.size() - 1).getId());
+        }
+        System.out.println(sb);
+        return sb.toString();
     }
 
     @Override

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/SysOutVisitor.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/SysOutVisitor.java
@@ -14,7 +14,7 @@ public class SysOutVisitor implements Visitor, StateChainVisitor {
 
     @Override
     public String visitOnEntry(StateMachine<?, ?, ?> stateMachine) {
-        String entry = "-----StateMachine:"+stateMachine.getMachineId()+"-------";
+        String entry = "-----StateMachine:" + stateMachine.getMachineId() + "-------";
         System.out.println(entry);
         return entry;
     }
@@ -29,7 +29,7 @@ public class SysOutVisitor implements Visitor, StateChainVisitor {
     @Override
     public String visitOnEntry(StateChain<?, ?> stateChain) {
         StringBuilder sb = new StringBuilder();
-        String entry = "-----StateChain-Event:+" + stateChain.getEvent() + "------";
+        String entry = "-----StateChain-Event: " + stateChain.getEvent() + "------";
         sb.append(entry).append(LF);
         System.out.println(entry);
         return sb.toString();
@@ -43,7 +43,7 @@ public class SysOutVisitor implements Visitor, StateChainVisitor {
     }
 
     @Override
-    public <S, C, E> String visitOnStateChain(List<State<S, E, C>> chainStateList, E event) {
+    public <S, E, C> String visitOnStateChain(List<State<S, E, C>> chainStateList, E event) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < chainStateList.size() - 1; i++) {
             State<S, E, C> sourceState = chainStateList.get(i);
@@ -59,11 +59,11 @@ public class SysOutVisitor implements Visitor, StateChainVisitor {
     @Override
     public String visitOnEntry(State<?, ?, ?> state) {
         StringBuilder sb = new StringBuilder();
-        String stateStr = "State:"+state.getId();
+        String stateStr = "State:" + state.getId();
         sb.append(stateStr).append(LF);
         System.out.println(stateStr);
-        for(Transition transition: state.getAllTransitions()){
-            String transitionStr = "    Transition:"+transition;
+        for (Transition transition : state.getAllTransitions()) {
+            String transitionStr = "    Transition:" + transition;
             sb.append(transitionStr).append(LF);
             System.out.println(transitionStr);
         }

--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/TransitionImpl.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/TransitionImpl.java
@@ -53,6 +53,11 @@ public class TransitionImpl<S,E,C> implements Transition<S,E,C> {
     }
 
     @Override
+    public TransitionType getType() {
+        return this.type;
+    }
+
+    @Override
     public State<S, E, C> getTarget() {
         return this.target;
     }

--- a/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateChainTest.java
+++ b/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateChainTest.java
@@ -1,0 +1,210 @@
+package com.alibaba.cola.test;
+
+import com.alibaba.cola.statemachine.Action;
+import com.alibaba.cola.statemachine.Condition;
+import com.alibaba.cola.statemachine.StateChain;
+import com.alibaba.cola.statemachine.StateMachine;
+import com.alibaba.cola.statemachine.builder.StateMachineBuilder;
+import com.alibaba.cola.statemachine.builder.StateMachineBuilderFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * StateChainTest
+ *
+ * @author benym
+ * @date 2024/6/12 18:57
+ */
+public class StateChainTest {
+
+    private static final Boolean DEBUG = false;
+
+    @Test
+    public void testGetTargetStates() {
+        StateMachineBuilder<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> builder = StateMachineBuilderFactory.create();
+        builder.internalTransition()
+                .within(StateMachineTest.States.STATE1)
+                .on(StateMachineTest.Events.EVENT1)
+                .when(checkCondition())
+                .perform(doAction());
+        builder.externalTransition()
+                .from(StateMachineTest.States.STATE1)
+                .to(StateMachineTest.States.STATE2)
+                .on(StateMachineTest.Events.EVENT1)
+                .when(checkCondition())
+                .perform(doAction());
+        builder.externalTransitions()
+                .fromAmong(StateMachineTest.States.STATE1, StateMachineTest.States.STATE2)
+                .to(StateMachineTest.States.STATE5)
+                .on(StateMachineTest.Events.EVENT3)
+                .when(checkCondition())
+                .perform(doAction());
+        builder.externalParallelTransition()
+                .from(StateMachineTest.States.STATE3)
+                .toAmong(StateMachineTest.States.STATE4, StateMachineTest.States.STATE5)
+                .on(StateMachineTest.Events.EVENT1)
+                .when(checkCondition())
+                .perform(doAction());
+        StateMachine<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> stateMachine = builder.build("TestGetTargetStatesMachine");
+        System.out.println(stateMachine.generatePlantUML());
+        List<StateMachineTest.States> targetStateList = stateMachine.getTargetStates(StateMachineTest.States.STATE1, StateMachineTest.Events.EVENT1);
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(2, new HashSet<>(targetStateList).size(),
+                        "The list should contain only two unique elements"),
+                () -> Assertions.assertTrue(targetStateList.stream().allMatch(s -> s.equals(StateMachineTest.States.STATE1) || s.equals(StateMachineTest.States.STATE2)),
+                        "The list should only contain 'state1' and 'state2'"),
+                () -> Assertions.assertFalse(targetStateList.contains(null),
+                        "The list should not contain null.")
+        );
+        List<StateMachineTest.States> targetStateList2 = stateMachine.getTargetStates(StateMachineTest.States.STATE1, StateMachineTest.Events.EVENT3);
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(1, new HashSet<>(targetStateList2).size(),
+                        "The list should contain only one unique elements"),
+                () -> Assertions.assertTrue(targetStateList2.stream().allMatch(s -> s.equals(StateMachineTest.States.STATE5)),
+                        "The list should only contain 'state5'"),
+                () -> Assertions.assertFalse(targetStateList2.contains(null),
+                        "The list should not contain null.")
+        );
+        List<StateMachineTest.States> targetStateList3 = stateMachine.getTargetStates(StateMachineTest.States.STATE2, StateMachineTest.Events.EVENT3);
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(1, new HashSet<>(targetStateList3).size(),
+                        "The list should contain only one unique elements"),
+                () -> Assertions.assertTrue(targetStateList3.stream().allMatch(s -> s.equals(StateMachineTest.States.STATE5)),
+                        "The list should only contain 'state5'"),
+                () -> Assertions.assertFalse(targetStateList3.contains(null),
+                        "The list should not contain null.")
+        );
+        List<StateMachineTest.States> targetStateList4 = stateMachine.getTargetStates(StateMachineTest.States.STATE3, StateMachineTest.Events.EVENT1);
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(2, new HashSet<>(targetStateList4).size(),
+                        "The list should contain only two unique elements"),
+                () -> Assertions.assertTrue(targetStateList4.stream().allMatch(s -> s.equals(StateMachineTest.States.STATE4) || s.equals(StateMachineTest.States.STATE5)),
+                        "The list should only contain 'state4' and 'state5'"),
+                () -> Assertions.assertFalse(targetStateList4.contains(null),
+                        "The list should not contain null.")
+        );
+    }
+
+    @Test
+    public void testGetTargetStateChain() {
+        StateMachineBuilder<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> builder = StateMachineBuilderFactory.create();
+        // event1
+        builder.internalTransition()
+                .within(StateMachineTest.States.STATE1)
+                .on(StateMachineTest.Events.EVENT1)
+                .when(checkCondition())
+                .perform(doAction());
+        builder.externalTransition()
+                .from(StateMachineTest.States.STATE1)
+                .to(StateMachineTest.States.STATE2)
+                .on(StateMachineTest.Events.EVENT1)
+                .when(checkCondition())
+                .perform(doAction());
+        builder.externalTransition()
+                .from(StateMachineTest.States.STATE2)
+                .to(StateMachineTest.States.STATE3)
+                .on(StateMachineTest.Events.EVENT1)
+                .when(checkCondition())
+                .perform(doAction());
+        builder.externalTransitions()
+                .fromAmong(StateMachineTest.States.STATE1, StateMachineTest.States.STATE2)
+                .to(StateMachineTest.States.STATE5)
+                .on(StateMachineTest.Events.EVENT1)
+                .when(checkCondition())
+                .perform(doAction());
+        builder.externalParallelTransition()
+                .from(StateMachineTest.States.STATE3)
+                .toAmong(StateMachineTest.States.STATE4, StateMachineTest.States.STATE5, StateMachineTest.States.STATE1)
+                .on(StateMachineTest.Events.EVENT1)
+                .when(checkCondition())
+                .perform(doAction());
+        StateMachine<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> stateMachine = builder.build("TestGetTargetStateChainMachine");
+        System.out.println(stateMachine.generatePlantUML());
+        System.out.println();
+        List<StateChain<StateMachineTest.States, StateMachineTest.Events>> targetStateChainList = stateMachine.getTargetStateChain(StateMachineTest.States.STATE1, StateMachineTest.Events.EVENT1);
+        targetStateChainList.forEach(
+                targetStateChain -> {
+                    targetStateChain.showStateChain();
+                    System.out.println();
+                    String plantUml = targetStateChain.generatePlantUml();
+                    System.out.println(plantUml);
+                    System.out.println();
+                    checkStateChain(targetStateChain);
+                }
+        );
+    }
+
+    private void checkStateChain(StateChain<StateMachineTest.States, StateMachineTest.Events> stateChain) {
+        boolean group1Passed;
+        boolean group2Passed;
+        boolean group3Passed;
+        boolean group4Passed;
+        boolean group5Passed;
+        boolean group6Passed;
+        StateMachineTest.States source = stateChain.getSource();
+        Assertions.assertEquals(source, StateMachineTest.States.STATE1);
+        group1Passed = checkGroup(stateChain.getTargets(), 1, List.of(StateMachineTest.States.STATE1));
+        group2Passed = checkGroup(stateChain.getTargets(), 3, List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE3, StateMachineTest.States.STATE4));
+        group3Passed = checkGroup(stateChain.getTargets(), 3, List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE3, StateMachineTest.States.STATE5));
+        group4Passed = checkGroup(stateChain.getTargets(), 3, List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE3, StateMachineTest.States.STATE1));
+        group5Passed = checkGroup(stateChain.getTargets(), 1, List.of(StateMachineTest.States.STATE5));
+        group6Passed = checkGroup(stateChain.getTargets(), 2, List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE5));
+        Assertions.assertTrue((group1Passed || group2Passed || group3Passed || group4Passed || group5Passed || group6Passed),
+                "At least one group of assertions should pass");
+    }
+
+    private boolean checkGroup(List<StateMachineTest.States> targets, Integer setNum, List<StateMachineTest.States> equalsList) {
+        boolean passed = true;
+        HashSet<StateMachineTest.States> uniqueStates = new HashSet<>(targets);
+        if (uniqueStates.size() != setNum) {
+            if (DEBUG) {
+                System.out.println("The list should contain only " + setNum + " unique elements");
+            }
+            passed = false;
+        }
+        for (StateMachineTest.States target : targets) {
+            if (target == null) {
+                if (DEBUG) {
+                    System.out.println("The list should not contain null.");
+                }
+                passed = false;
+                break;
+            }
+            boolean foundMatch = false;
+            for (StateMachineTest.States state : equalsList) {
+                if (target.equals(state)) {
+                    foundMatch = true;
+                    break;
+                }
+            }
+            if (!foundMatch) {
+                if (DEBUG) {
+                    System.out.println("The list should only contain elements from the provided equalsList.");
+                }
+                passed = false;
+                break;
+            }
+        }
+        return passed;
+    }
+
+    private Condition<StateMachineTest.Context> checkCondition() {
+        return new Condition<StateMachineTest.Context>() {
+            @Override
+            public boolean isSatisfied(StateMachineTest.Context context) {
+                System.out.println("Check condition : " + context);
+                return true;
+            }
+        };
+    }
+
+    private Action<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> doAction() {
+        return (from, to, event, ctx) -> {
+            System.out.println(
+                    ctx.operator + " is operating " + ctx.entityId + " from:" + from + " to:" + to + " on:" + event);
+        };
+    }
+}

--- a/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateChainTest.java
+++ b/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateChainTest.java
@@ -6,6 +6,7 @@ import com.alibaba.cola.statemachine.StateChain;
 import com.alibaba.cola.statemachine.StateMachine;
 import com.alibaba.cola.statemachine.builder.StateMachineBuilder;
 import com.alibaba.cola.statemachine.builder.StateMachineBuilderFactory;
+import com.alibaba.cola.statemachine.impl.Debugger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -19,8 +20,6 @@ import java.util.List;
  * @date 2024/6/12 18:57
  */
 public class StateChainTest {
-
-    private static final Boolean DEBUG = false;
 
     @Test
     public void testGetTargetStates() {
@@ -160,16 +159,12 @@ public class StateChainTest {
         boolean passed = true;
         HashSet<StateMachineTest.States> uniqueStates = new HashSet<>(targets);
         if (uniqueStates.size() != setNum) {
-            if (DEBUG) {
-                System.out.println("The list should contain only " + setNum + " unique elements");
-            }
+            Debugger.debug("The list should contain only " + setNum + " unique elements");
             passed = false;
         }
         for (StateMachineTest.States target : targets) {
             if (target == null) {
-                if (DEBUG) {
-                    System.out.println("The list should not contain null.");
-                }
+                Debugger.debug("The list should not contain null");
                 passed = false;
                 break;
             }
@@ -181,9 +176,7 @@ public class StateChainTest {
                 }
             }
             if (!foundMatch) {
-                if (DEBUG) {
-                    System.out.println("The list should only contain elements from the provided equalsList.");
-                }
+                Debugger.debug("The list should only contain elements from the provided equalsList");
                 passed = false;
                 break;
             }

--- a/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateChainTest.java
+++ b/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateChainTest.java
@@ -160,7 +160,7 @@ public class StateChainTest {
                 List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE5));
 
         Set<List<StateMachineTest.States>> actualChains = targetStateChainList.stream()
-                .map(StateChain::getTargets)
+                .map(StateChain::getChainStates)
                 .collect(Collectors.toSet());
 
         Assertions.assertAll(

--- a/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateChainTest.java
+++ b/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateChainTest.java
@@ -6,12 +6,14 @@ import com.alibaba.cola.statemachine.StateChain;
 import com.alibaba.cola.statemachine.StateMachine;
 import com.alibaba.cola.statemachine.builder.StateMachineBuilder;
 import com.alibaba.cola.statemachine.builder.StateMachineBuilderFactory;
-import com.alibaba.cola.statemachine.impl.Debugger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * StateChainTest
@@ -23,7 +25,8 @@ public class StateChainTest {
 
     @Test
     public void testGetTargetStates() {
-        StateMachineBuilder<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> builder = StateMachineBuilderFactory.create();
+        StateMachineBuilder<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> builder = StateMachineBuilderFactory
+                .create();
         builder.internalTransition()
                 .within(StateMachineTest.States.STATE1)
                 .on(StateMachineTest.Events.EVENT1)
@@ -47,50 +50,59 @@ public class StateChainTest {
                 .on(StateMachineTest.Events.EVENT1)
                 .when(checkCondition())
                 .perform(doAction());
-        StateMachine<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> stateMachine = builder.build("TestGetTargetStatesMachine");
+        StateMachine<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> stateMachine = builder
+                .build("TestGetTargetStatesMachine");
         System.out.println(stateMachine.generatePlantUML());
-        List<StateMachineTest.States> targetStateList = stateMachine.getTargetStates(StateMachineTest.States.STATE1, StateMachineTest.Events.EVENT1);
+        List<StateMachineTest.States> targetStateList = stateMachine
+                .getTargetStates(StateMachineTest.States.STATE1, StateMachineTest.Events.EVENT1);
         Assertions.assertAll(
                 () -> Assertions.assertEquals(2, new HashSet<>(targetStateList).size(),
                         "The list should contain only two unique elements"),
-                () -> Assertions.assertTrue(targetStateList.stream().allMatch(s -> s.equals(StateMachineTest.States.STATE1) || s.equals(StateMachineTest.States.STATE2)),
+                () -> Assertions.assertTrue(targetStateList.stream()
+                                .allMatch(s -> s.equals(StateMachineTest.States.STATE1)
+                                        || s.equals(StateMachineTest.States.STATE2)),
                         "The list should only contain 'state1' and 'state2'"),
                 () -> Assertions.assertFalse(targetStateList.contains(null),
-                        "The list should not contain null.")
-        );
-        List<StateMachineTest.States> targetStateList2 = stateMachine.getTargetStates(StateMachineTest.States.STATE1, StateMachineTest.Events.EVENT3);
+                        "The list should not contain null."));
+        List<StateMachineTest.States> targetStateList2 = stateMachine
+                .getTargetStates(StateMachineTest.States.STATE1, StateMachineTest.Events.EVENT3);
         Assertions.assertAll(
                 () -> Assertions.assertEquals(1, new HashSet<>(targetStateList2).size(),
                         "The list should contain only one unique elements"),
-                () -> Assertions.assertTrue(targetStateList2.stream().allMatch(s -> s.equals(StateMachineTest.States.STATE5)),
+                () -> Assertions.assertTrue(
+                        targetStateList2.stream().allMatch(
+                                s -> s.equals(StateMachineTest.States.STATE5)),
                         "The list should only contain 'state5'"),
                 () -> Assertions.assertFalse(targetStateList2.contains(null),
-                        "The list should not contain null.")
-        );
-        List<StateMachineTest.States> targetStateList3 = stateMachine.getTargetStates(StateMachineTest.States.STATE2, StateMachineTest.Events.EVENT3);
+                        "The list should not contain null."));
+        List<StateMachineTest.States> targetStateList3 = stateMachine
+                .getTargetStates(StateMachineTest.States.STATE2, StateMachineTest.Events.EVENT3);
         Assertions.assertAll(
                 () -> Assertions.assertEquals(1, new HashSet<>(targetStateList3).size(),
                         "The list should contain only one unique elements"),
-                () -> Assertions.assertTrue(targetStateList3.stream().allMatch(s -> s.equals(StateMachineTest.States.STATE5)),
+                () -> Assertions.assertTrue(
+                        targetStateList3.stream().allMatch(
+                                s -> s.equals(StateMachineTest.States.STATE5)),
                         "The list should only contain 'state5'"),
                 () -> Assertions.assertFalse(targetStateList3.contains(null),
-                        "The list should not contain null.")
-        );
-        List<StateMachineTest.States> targetStateList4 = stateMachine.getTargetStates(StateMachineTest.States.STATE3, StateMachineTest.Events.EVENT1);
+                        "The list should not contain null."));
+        List<StateMachineTest.States> targetStateList4 = stateMachine
+                .getTargetStates(StateMachineTest.States.STATE3, StateMachineTest.Events.EVENT1);
         Assertions.assertAll(
                 () -> Assertions.assertEquals(2, new HashSet<>(targetStateList4).size(),
                         "The list should contain only two unique elements"),
-                () -> Assertions.assertTrue(targetStateList4.stream().allMatch(s -> s.equals(StateMachineTest.States.STATE4) || s.equals(StateMachineTest.States.STATE5)),
+                () -> Assertions.assertTrue(targetStateList4.stream()
+                                .allMatch(s -> s.equals(StateMachineTest.States.STATE4)
+                                        || s.equals(StateMachineTest.States.STATE5)),
                         "The list should only contain 'state4' and 'state5'"),
                 () -> Assertions.assertFalse(targetStateList4.contains(null),
-                        "The list should not contain null.")
-        );
+                        "The list should not contain null."));
     }
 
     @Test
     public void testGetTargetStateChain() {
-        StateMachineBuilder<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> builder = StateMachineBuilderFactory.create();
-        // event1
+        StateMachineBuilder<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> builder = StateMachineBuilderFactory
+                .create();
         builder.internalTransition()
                 .within(StateMachineTest.States.STATE1)
                 .on(StateMachineTest.Events.EVENT1)
@@ -116,14 +128,17 @@ public class StateChainTest {
                 .perform(doAction());
         builder.externalParallelTransition()
                 .from(StateMachineTest.States.STATE3)
-                .toAmong(StateMachineTest.States.STATE4, StateMachineTest.States.STATE5, StateMachineTest.States.STATE1)
+                .toAmong(StateMachineTest.States.STATE4, StateMachineTest.States.STATE5,
+                        StateMachineTest.States.STATE1)
                 .on(StateMachineTest.Events.EVENT1)
                 .when(checkCondition())
                 .perform(doAction());
-        StateMachine<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> stateMachine = builder.build("TestGetTargetStateChainMachine");
+        StateMachine<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> stateMachine = builder
+                .build("TestGetTargetStateChainMachine");
         System.out.println(stateMachine.generatePlantUML());
         System.out.println();
-        List<StateChain<StateMachineTest.States, StateMachineTest.Events>> targetStateChainList = stateMachine.getTargetStateChain(StateMachineTest.States.STATE1, StateMachineTest.Events.EVENT1);
+        List<StateChain<StateMachineTest.States, StateMachineTest.Events>> targetStateChainList = stateMachine
+                .getTargetStateChain(StateMachineTest.States.STATE1, StateMachineTest.Events.EVENT1);
         targetStateChainList.forEach(
                 targetStateChain -> {
                     targetStateChain.showStateChain();
@@ -131,57 +146,40 @@ public class StateChainTest {
                     String plantUml = targetStateChain.generatePlantUml();
                     System.out.println(plantUml);
                     System.out.println();
-                    checkStateChain(targetStateChain);
-                }
-        );
-    }
+                });
 
-    private void checkStateChain(StateChain<StateMachineTest.States, StateMachineTest.Events> stateChain) {
-        boolean group1Passed;
-        boolean group2Passed;
-        boolean group3Passed;
-        boolean group4Passed;
-        boolean group5Passed;
-        boolean group6Passed;
-        StateMachineTest.States source = stateChain.getSource();
-        Assertions.assertEquals(source, StateMachineTest.States.STATE1);
-        group1Passed = checkGroup(stateChain.getTargets(), 1, List.of(StateMachineTest.States.STATE1));
-        group2Passed = checkGroup(stateChain.getTargets(), 3, List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE3, StateMachineTest.States.STATE4));
-        group3Passed = checkGroup(stateChain.getTargets(), 3, List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE3, StateMachineTest.States.STATE5));
-        group4Passed = checkGroup(stateChain.getTargets(), 3, List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE3, StateMachineTest.States.STATE1));
-        group5Passed = checkGroup(stateChain.getTargets(), 1, List.of(StateMachineTest.States.STATE5));
-        group6Passed = checkGroup(stateChain.getTargets(), 2, List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE5));
-        Assertions.assertTrue((group1Passed || group2Passed || group3Passed || group4Passed || group5Passed || group6Passed),
-                "At least one group of assertions should pass");
-    }
+        Set<List<StateMachineTest.States>> expectedChains = Set.of(
+                List.of(StateMachineTest.States.STATE1),
+                List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE3,
+                        StateMachineTest.States.STATE4),
+                List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE3,
+                        StateMachineTest.States.STATE5),
+                List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE3,
+                        StateMachineTest.States.STATE1),
+                List.of(StateMachineTest.States.STATE5),
+                List.of(StateMachineTest.States.STATE2, StateMachineTest.States.STATE5));
 
-    private boolean checkGroup(List<StateMachineTest.States> targets, Integer setNum, List<StateMachineTest.States> equalsList) {
-        boolean passed = true;
-        HashSet<StateMachineTest.States> uniqueStates = new HashSet<>(targets);
-        if (uniqueStates.size() != setNum) {
-            Debugger.debug("The list should contain only " + setNum + " unique elements");
-            passed = false;
-        }
-        for (StateMachineTest.States target : targets) {
-            if (target == null) {
-                Debugger.debug("The list should not contain null");
-                passed = false;
-                break;
-            }
-            boolean foundMatch = false;
-            for (StateMachineTest.States state : equalsList) {
-                if (target.equals(state)) {
-                    foundMatch = true;
-                    break;
-                }
-            }
-            if (!foundMatch) {
-                Debugger.debug("The list should only contain elements from the provided equalsList");
-                passed = false;
-                break;
-            }
-        }
-        return passed;
+        Set<List<StateMachineTest.States>> actualChains = targetStateChainList.stream()
+                .map(StateChain::getTargets)
+                .collect(Collectors.toSet());
+
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(expectedChains.size(), actualChains.size(),
+                        "StateChain count should match expected"),
+                () -> Assertions.assertTrue(expectedChains.containsAll(actualChains),
+                        "Actual chains should match expected chains"),
+                () -> Assertions.assertTrue(actualChains.containsAll(expectedChains),
+                        "All expected chains should be present"),
+                () -> Assertions.assertTrue(
+                        actualChains.stream()
+                                .allMatch(chain -> chain.stream()
+                                        .noneMatch(Objects::isNull)),
+                        "No chain should contain null elements"));
+
+        targetStateChainList.forEach(stateChain -> {
+            Assertions.assertEquals(StateMachineTest.States.STATE1, stateChain.getSource(),
+                    "Source state should be STATE1");
+        });
     }
 
     private Condition<StateMachineTest.Context> checkCondition() {
@@ -197,7 +195,8 @@ public class StateChainTest {
     private Action<StateMachineTest.States, StateMachineTest.Events, StateMachineTest.Context> doAction() {
         return (from, to, event, ctx) -> {
             System.out.println(
-                    ctx.operator + " is operating " + ctx.entityId + " from:" + from + " to:" + to + " on:" + event);
+                    ctx.operator + " is operating " + ctx.entityId + " from:" + from + " to:" + to
+                            + " on:" + event);
         };
     }
 }

--- a/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateMachineTest.java
+++ b/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateMachineTest.java
@@ -1,9 +1,6 @@
 package com.alibaba.cola.test;
 
-import com.alibaba.cola.statemachine.Action;
-import com.alibaba.cola.statemachine.Condition;
-import com.alibaba.cola.statemachine.StateMachine;
-import com.alibaba.cola.statemachine.StateMachineFactory;
+import com.alibaba.cola.statemachine.*;
 import com.alibaba.cola.statemachine.builder.AlertFailCallback;
 import com.alibaba.cola.statemachine.builder.StateMachineBuilder;
 import com.alibaba.cola.statemachine.builder.StateMachineBuilderFactory;
@@ -28,7 +25,8 @@ public class StateMachineTest {
         STATE1,
         STATE2,
         STATE3,
-        STATE4
+        STATE4,
+        STATE5
     }
 
     static enum Events {


### PR DESCRIPTION
虽然状态机在内部DSL维护了状态转移规则，但在实际使用过程中
发现不能够通过当前状态+事件获取到后续可能转移到的状态，DSL转移过程除UML图外不支持代码获取

比如场景

正向状态，待审核->业务审核通过->商务审核通过->法务审核通过

反向状态，待审核->业务审核驳回
		 待审核->业务审核通过->商务审核驳回
		 待审核->业务审核通过->商务审核通过->法务审核驳回

事件是审核通过、审核拒绝
在这个场景中通过待审核初始状态+审核通过事件，能够走到正向链路的最后，这条链路可能是需要展示出去的

更加通用的情况是：
通过当前状态+事件获取后续节点，或后续状态链
如果单独再维护一套等价于DSL转移过程的代码显得有点烦琐
除此之外也为了增加代码维度对后续状态获取的透明度，当状态机状态较多时提升状态链路可预测性

基于上述情况
新增4个功能
1. com.alibaba.cola.statemachine.StateMachine#getTargetStates，支持从当前状态+事件获取DSL中下一跳状态
2. com.alibaba.cola.statemachine.StateMachine#getTargetStateChain，支持从当前状态+事件获取DSL中的状态链，全面考虑现有internalTransition、externalTransition、externalTransitions、externalParallelTransition链路内部转化，一对一串行，一对多，多对一，环形链路等情况
3. com.alibaba.cola.statemachine.StateChain#showStateChain，支持状态链的控制台打印可视化
4. com.alibaba.cola.statemachine.StateChain#generatePlantUml，支持状态链PlantUml可视化

对应单元测试
com.alibaba.cola.test.StateChainTest

具体示例
给定如下状态机
![image](https://github.com/alibaba/COLA/assets/38175888/922f7024-3682-40ae-968a-72deff9d644b)
获取初始状态为STATE1, 事件为EVENT1的，状态链为
![image](https://github.com/alibaba/COLA/assets/38175888/f5cfc5b4-2ec1-49ab-abe9-2f6d729efb7b)
