### PR TITLE
事件触发时，增加链式Action的抽象实现，让状态流转时，可以执行多个动作

### DIFF
--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/AbsChainAction.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/impl/AbsChainAction.java
@@ -1,0 +1,29 @@
+package com.alibaba.cola.statemachine.impl;
+
+import com.alibaba.cola.statemachine.Action;
+
+import java.util.Objects;
+
+/**
+ * @author WUXIN
+ * @date 2024/10/14 23:56:10
+ */
+public abstract class AbsChainAction<S,E,C> implements Action<S,E,C> {
+
+    private Action next;
+
+    @Override
+    public void execute(S from, S to, E event, C context) {
+        doExecute(from, to, event, context);
+        if(Objects.nonNull(next)){
+            next.execute(from, to, event, context);
+        }
+    }
+
+    protected abstract void doExecute(S from, S to, E event, C context);
+
+    public AbsChainAction next(Action action){
+        this.next = action;
+        return this;
+    }
+}

--- a/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateMachineTest.java
+++ b/cola-components/cola-component-statemachine/src/test/java/com/alibaba/cola/test/StateMachineTest.java
@@ -8,6 +8,7 @@ import com.alibaba.cola.statemachine.builder.AlertFailCallback;
 import com.alibaba.cola.statemachine.builder.StateMachineBuilder;
 import com.alibaba.cola.statemachine.builder.StateMachineBuilderFactory;
 import com.alibaba.cola.statemachine.exception.TransitionFailException;
+import com.alibaba.cola.statemachine.impl.AbsChainAction;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -91,6 +92,38 @@ public class StateMachineTest {
         Assertions.assertTrue(stateMachine.verify(States.STATE1, Events.EVENT1));
         Assertions.assertFalse(stateMachine.verify(States.STATE1, Events.EVENT2));
     }
+
+    @Test
+    public void testChainAction(){
+        StateMachineBuilder<States, Events, Context> builder = StateMachineBuilderFactory.create();
+        builder.externalTransition()
+                .from(States.STATE1)
+                .to(States.STATE2)
+                .on(Events.EVENT1)
+                .when(checkCondition())
+                .perform(
+                        new AbsChainAction<States, Events, Context>() {
+                            @Override
+                            protected void doExecute(States from, States to, Events event, Context context) {
+                                System.out.println("first action to execute");
+                            }
+                        }.next(new AbsChainAction() {
+                            @Override
+                            protected void doExecute(Object from, Object to, Object event, Object context) {
+                                System.out.println("second action to execute");
+                            }
+                        }.next(new AbsChainAction() {
+                            @Override
+                            protected void doExecute(Object from, Object to, Object event, Object context) {
+                                System.out.println("third action to execute");
+                            }
+                        }))
+                )
+        ;
+        builder.build("test-perform-chan-action").fireEvent(States.STATE1,Events.EVENT1,new Context());
+
+    }
+
 
     @Test
     public void testExternalTransitionsNormal() {


### PR DESCRIPTION
状态机引擎发生状态流转时，触发的动作只能是一个。
现在增加一个对Action接口的抽象类，来维护一个责任链，和一个模板方法（链式触发），增加一个抽象方法（让自类实现业务行为）
以让对应的事件发生时，可以触发多个动作。