### PR TITLE
fix: 修复 cola-archetype-light 5.0.0 中 test-container 依赖版本错误

### DIFF
--- a/cola-archetypes/cola-archetype-light/src/main/resources/archetype-resources/pom.xml
+++ b/cola-archetypes/cola-archetype-light/src/main/resources/archetype-resources/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.alibaba.cola</groupId>
             <artifactId>cola-component-test-container</artifactId>
-            <version>4.4.0-SNAPSHOT</version>
+            <version>5.0.0</version>
         </dependency>
         <!--this for embedded database unit test-->
         <dependency>

--- a/cola-samples/charge/pom.xml
+++ b/cola-samples/charge/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.alibaba.cola</groupId>
             <artifactId>cola-component-test-container</artifactId>
-            <version>4.4.0-SNAPSHOT</version>
+            <version>5.0.0</version>
         </dependency>
         <!--this for embedded database unit test-->
         <dependency>


### PR DESCRIPTION
## 一、变更内容

本次 PR 修复 cola-archetype-light:5.0.0 脚手架模板中的依赖版本问题。

当前使用 cola-archetype-light:5.0.0 创建项目后，生成项目中的 cola-component-test-container 依赖版本为：

xml <dependency>     <groupId>com.alibaba.cola</groupId>     <artifactId>cola-component-test-container</artifactId>     <version>4.4.0-SNAPSHOT</version> </dependency> 

该版本在 Maven 仓库中无法解析，导致生成项目执行 Maven install 时构建失败。

本次修复将该依赖版本调整为：

xml <dependency>     <groupId>com.alibaba.cola</groupId>     <artifactId>cola-component-test-container</artifactId>     <version>5.0.0</version> </dependency> 

## 二、问题原因

使用 IntelliJ IDEA 创建 Maven Archetype 项目时，选择：

text com.alibaba.cola:cola-archetype-light:5.0.0 

项目创建成功后执行：

bash mvn clean install 

会出现以下错误：

text Could not find artifact com.alibaba.cola:cola-component-test-container:jar:4.4.0-SNAPSHOT 

经检查，生成项目的 pom.xml 中仍然引用了旧版本：

text 4.4.0-SNAPSHOT 

而当前脚手架版本为 5.0.0，并且 Maven 仓库中无法找到对应的 4.4.0-SNAPSHOT 依赖。

因此判断是 cola-archetype-light:5.0.0 的模板文件中残留了旧的依赖版本号。

## 三、复现环境

- 操作系统：macOS
- 设备型号：MacBook Pro M2 Pro
- JDK 版本：JDK 17
- Maven 版本：Apache Maven 3.9.11
- IDE：IntelliJ IDEA
- Maven Archetype：com.alibaba.cola:cola-archetype-light:5.0.0

## 四、复现步骤

1. 使用 IntelliJ IDEA 创建新项目
2. 选择 Maven Archetype 创建方式
3. 选择以下 COLA 脚手架版本：

text com.alibaba.cola:cola-archetype-light:5.0.0 

4. 项目创建完成后，在项目根目录执行：

bash mvn clean install 

5. Maven 构建失败，提示：

text Could not find artifact com.alibaba.cola:cola-component-test-container:jar:4.4.0-SNAPSHOT 

## 五、验证结果

将 cola-component-test-container 的依赖版本从：

text 4.4.0-SNAPSHOT 

修改为：

text 5.0.0 

后，重新执行：

bash mvn clean install 

项目可以正常构建。

## 六、关联 Issue

Fixes #600